### PR TITLE
Capture JSON response body

### DIFF
--- a/dist/cjs/api/Telescope.js
+++ b/dist/cjs/api/Telescope.js
@@ -109,7 +109,7 @@ class Telescope {
         });
     }
     resolveDir() {
-        let dir = process.cwd() + '/node_modules/@damianchojnacki/telescope/dist/';
+        let dir = process.cwd() + '/node_modules/@asule/node-telescope/dist/';
         if (!(0, fs_1.existsSync)(dir + 'index.html')) {
             dir = path_1.default.join(process.cwd(), '/dist/');
         }

--- a/dist/cjs/api/watchers/RequestWatcher.js
+++ b/dist/cjs/api/watchers/RequestWatcher.js
@@ -83,8 +83,8 @@ class RequestWatcher {
         const oldSend = this.response.send;
         this.response.send = (content) => {
             const parsedContent = this.response.get('Content-Type')?.includes('application/json') ? JSON.parse(content) : content;
-            const sent = oldSend.call(this.response, parsedContent);
-            callback(this.contentWithinLimits(content));
+            const sent = oldSend.call(this.response, content);
+            callback(this.contentWithinLimits(parsedContent));
             return sent;
         };
     }

--- a/dist/cjs/api/watchers/RequestWatcher.js
+++ b/dist/cjs/api/watchers/RequestWatcher.js
@@ -82,7 +82,8 @@ class RequestWatcher {
     interceptResponse(callback) {
         const oldSend = this.response.send;
         this.response.send = (content) => {
-            const sent = oldSend.call(this.response, content);
+            const parsedContent = this.response.get('Content-Type')?.includes('application/json') ? JSON.parse(content) : content;
+            const sent = oldSend.call(this.response, parsedContent);
             callback(this.contentWithinLimits(content));
             return sent;
         };

--- a/dist/esm/api/Telescope.js
+++ b/dist/esm/api/Telescope.js
@@ -103,7 +103,7 @@ export default class Telescope {
         });
     }
     resolveDir() {
-        let dir = process.cwd() + '/node_modules/@damianchojnacki/telescope/dist/';
+        let dir = process.cwd() + '/node_modules/@asule/node-telescope/dist/';
         if (!existsSync(dir + 'index.html')) {
             dir = path.join(process.cwd(), '/dist/');
         }

--- a/dist/esm/api/watchers/RequestWatcher.js
+++ b/dist/esm/api/watchers/RequestWatcher.js
@@ -53,8 +53,8 @@ export default class RequestWatcher {
         const oldSend = this.response.send;
         this.response.send = (content) => {
             const parsedContent = this.response.get('Content-Type')?.includes('application/json') ? JSON.parse(content) : content;
-            const sent = oldSend.call(this.response, parsedContent);
-            callback(this.contentWithinLimits(content));
+            const sent = oldSend.call(this.response, content);
+            callback(this.contentWithinLimits(parsedContent));
             return sent;
         };
     }

--- a/dist/esm/api/watchers/RequestWatcher.js
+++ b/dist/esm/api/watchers/RequestWatcher.js
@@ -52,7 +52,8 @@ export default class RequestWatcher {
     interceptResponse(callback) {
         const oldSend = this.response.send;
         this.response.send = (content) => {
-            const sent = oldSend.call(this.response, content);
+            const parsedContent = this.response.get('Content-Type')?.includes('application/json') ? JSON.parse(content) : content;
+            const sent = oldSend.call(this.response, parsedContent);
             callback(this.contentWithinLimits(content));
             return sent;
         };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@damianchojnacki/telescope",
-  "version": "1.0.6",
+  "name": "@asule/node-telescope",
+  "version": "1.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@damianchojnacki/telescope",
-      "version": "1.0.6",
+      "name": "@asule/node-telescope",
+      "version": "1.0.9",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.9.0",

--- a/src/api/Telescope.ts
+++ b/src/api/Telescope.ts
@@ -183,7 +183,7 @@ export default class Telescope
 
     private resolveDir(): string
     {
-        let dir = process.cwd() + '/node_modules/@damianchojnacki/telescope/dist/'
+        let dir = process.cwd() + '/node_modules/@asule/node-telescope/dist/'
 
         if(!existsSync(dir + 'index.html')){
             dir = path.join(process.cwd(), '/dist/')

--- a/src/api/watchers/RequestWatcher.ts
+++ b/src/api/watchers/RequestWatcher.ts
@@ -119,9 +119,9 @@ export default class RequestWatcher
         {
             const parsedContent = this.response.get('Content-Type')?.includes('application/json') ? JSON.parse(content) : content;
 
-            const sent = oldSend.call(this.response, parsedContent)
+            const sent = oldSend.call(this.response, content)
 
-            callback(this.contentWithinLimits(content))
+            callback(this.contentWithinLimits(parsedContent))
 
             return sent
         }

--- a/src/api/watchers/RequestWatcher.ts
+++ b/src/api/watchers/RequestWatcher.ts
@@ -117,7 +117,9 @@ export default class RequestWatcher
 
         this.response.send = (content) =>
         {
-            const sent = oldSend.call(this.response, content)
+            const parsedContent = this.response.get('Content-Type')?.includes('application/json') ? JSON.parse(content) : content;
+
+            const sent = oldSend.call(this.response, parsedContent)
 
             callback(this.contentWithinLimits(content))
 


### PR DESCRIPTION
# Summary

This pull request updates the `Telescope` and `RequestWatcher` classes to improve dependency management and enhance response handling for JSON content. Below are the key changes:

### Dependency Update:

* Updated the directory path in the `Telescope` class to reflect a new dependency (`@asule/node-telescope`) instead of the previous one (`@damianchojnacki/telescope`) in `src/api/Telescope.ts`.

### Response Handling Enhancement:

* Modified the `RequestWatcher` class to parse JSON content automatically when the `Content-Type` header indicates `application/json`, ensuring consistent handling of JSON responses in `src/api/watchers/RequestWatcher.ts`.

# Problem It Solves

The current implementation captures the response body literally which is a string. This means that even if a JSON was sent as response, it's string representation was captured.

<img width="1178" height="154" alt="Response body stored as string" src="https://github.com/user-attachments/assets/dd200ccf-1916-4292-9f82-929f85b394b3" />

# The Solution

Check the response content type and if it is JSON, parse the string to get the original JSON response and capture it instead.

<img width="424" height="251" alt="Response body stored as JSON" src="https://github.com/user-attachments/assets/3a277f4f-e1af-453b-9093-9d0eaa3e3514" />

In addition we get pretty output of the response body.