### PR TITLE
Change Target to ES2022

### DIFF
--- a/dist/cjs/api/DB.js
+++ b/dist/cjs/api/DB.js
@@ -6,6 +6,8 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const LowDriver_js_1 = __importDefault(require("./drivers/LowDriver.js"));
 const WatcherEntry_js_1 = require("./WatcherEntry.js");
 class DB {
+    static driver = LowDriver_js_1.default;
+    static db;
     constructor() {
         DB.db = new DB.driver();
     }
@@ -45,5 +47,4 @@ class DB {
         return DB.db;
     }
 }
-DB.driver = LowDriver_js_1.default;
 exports.default = DB;

--- a/dist/cjs/api/Telescope.js
+++ b/dist/cjs/api/Telescope.js
@@ -109,7 +109,7 @@ class Telescope {
         });
     }
     resolveDir() {
-        let dir = process.cwd() + '/node_modules/@damianchojnacki/telescope/dist/';
+        let dir = process.cwd() + '/node_modules/@asule/node-telescope/dist/';
         if (!(0, fs_1.existsSync)(dir + 'index.html')) {
             dir = path_1.default.join(process.cwd(), '/dist/');
         }

--- a/dist/cjs/api/Telescope.js
+++ b/dist/cjs/api/Telescope.js
@@ -19,6 +19,16 @@ const node_events_1 = __importDefault(require("node:events"));
 const telescopeEmitter = new node_events_1.default();
 exports.eventEmitter = telescopeEmitter;
 class Telescope {
+    static enabledWatchers = [
+        RequestWatcher_js_1.default,
+        ErrorWatcher_js_1.default,
+        ClientRequestWatcher_js_1.default,
+        DumpWatcher_js_1.default,
+        LogWatcher_js_1.default
+    ];
+    app;
+    batchId;
+    static enableClient = true;
     constructor(app) {
         this.app = app;
     }
@@ -129,11 +139,3 @@ class Telescope {
     }
 }
 exports.default = Telescope;
-Telescope.enabledWatchers = [
-    RequestWatcher_js_1.default,
-    ErrorWatcher_js_1.default,
-    ClientRequestWatcher_js_1.default,
-    DumpWatcher_js_1.default,
-    LogWatcher_js_1.default
-];
-Telescope.enableClient = true;

--- a/dist/cjs/api/WatcherEntry.js
+++ b/dist/cjs/api/WatcherEntry.js
@@ -21,6 +21,14 @@ var WatcherEntryCollectionType;
     WatcherEntryCollectionType["clientRequest"] = "client-requests";
 })(WatcherEntryCollectionType = exports.WatcherEntryCollectionType || (exports.WatcherEntryCollectionType = {}));
 class WatcherEntry {
+    content;
+    created_at;
+    family_hash;
+    id;
+    batchId;
+    sequence;
+    tags;
+    type;
     constructor(name, data, batchId) {
         this.id = (0, uuid_1.v4)();
         this.created_at = new Date().toISOString();

--- a/dist/cjs/api/drivers/JSONFileSyncAdapter.js
+++ b/dist/cjs/api/drivers/JSONFileSyncAdapter.js
@@ -1,25 +1,25 @@
 "use strict";
-var __classPrivateFieldSet = (this && this.__classPrivateFieldSet) || function (receiver, state, value, kind, f) {
-    if (kind === "m") throw new TypeError("Private method is not writable");
-    if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a setter");
-    if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot write private member to an object whose class did not declare it");
-    return (kind === "a" ? f.call(receiver, value) : f ? f.value = value : state.set(receiver, value)), value;
-};
-var __classPrivateFieldGet = (this && this.__classPrivateFieldGet) || function (receiver, state, kind, f) {
-    if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a getter");
-    if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot read private member from an object whose class did not declare it");
-    return kind === "m" ? f : kind === "a" ? f.call(receiver) : f ? f.value : state.get(receiver);
-};
-var _JSONFileSyncAdapter_adapter;
 Object.defineProperty(exports, "__esModule", { value: true });
 const TextFileSync_js_1 = require("./TextFileSync.js");
 class JSONFileSyncAdapter {
+    #adapter;
     constructor(filename) {
-        _JSONFileSyncAdapter_adapter.set(this, void 0);
-        __classPrivateFieldSet(this, _JSONFileSyncAdapter_adapter, new TextFileSync_js_1.TextFileSync(filename), "f");
+        this.#adapter = new TextFileSync_js_1.TextFileSync(filename);
     }
+    static getRefReplacer = () => {
+        const seen = new WeakSet();
+        return (key, value) => {
+            if (typeof value === "object" && value !== null) {
+                if (seen.has(value)) {
+                    return '[Circular]';
+                }
+                seen.add(value);
+            }
+            return value;
+        };
+    };
     read() {
-        const data = __classPrivateFieldGet(this, _JSONFileSyncAdapter_adapter, "f").read();
+        const data = this.#adapter.read();
         if (data === null) {
             return null;
         }
@@ -28,20 +28,7 @@ class JSONFileSyncAdapter {
         }
     }
     write(obj) {
-        __classPrivateFieldGet(this, _JSONFileSyncAdapter_adapter, "f").write(JSON.stringify(obj, JSONFileSyncAdapter.getRefReplacer(), 2));
+        this.#adapter.write(JSON.stringify(obj, JSONFileSyncAdapter.getRefReplacer(), 2));
     }
 }
 exports.default = JSONFileSyncAdapter;
-_JSONFileSyncAdapter_adapter = new WeakMap();
-JSONFileSyncAdapter.getRefReplacer = () => {
-    const seen = new WeakSet();
-    return (key, value) => {
-        if (typeof value === "object" && value !== null) {
-            if (seen.has(value)) {
-                return '[Circular]';
-            }
-            seen.add(value);
-        }
-        return value;
-    };
-};

--- a/dist/cjs/api/drivers/LowDriver.js
+++ b/dist/cjs/api/drivers/LowDriver.js
@@ -6,15 +6,16 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const fs_1 = require("fs");
 const JSONFileSyncAdapter_js_1 = __importDefault(require("./JSONFileSyncAdapter.js"));
 class LowDriver {
+    adapter;
+    db = {
+        requests: [],
+        exceptions: [],
+        dumps: [],
+        logs: [],
+        queries: [],
+        "client-requests": [],
+    };
     constructor() {
-        this.db = {
-            requests: [],
-            exceptions: [],
-            dumps: [],
-            logs: [],
-            queries: [],
-            "client-requests": [],
-        };
         this.adapter = new JSONFileSyncAdapter_js_1.default('db.json');
         this.adapter.read();
     }

--- a/dist/cjs/api/drivers/MemoryDriver.js
+++ b/dist/cjs/api/drivers/MemoryDriver.js
@@ -1,6 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 class MemoryDriver {
+    db;
     constructor() {
         this.db = {
             requests: [],

--- a/dist/cjs/api/drivers/TextFileSync.js
+++ b/dist/cjs/api/drivers/TextFileSync.js
@@ -1,34 +1,22 @@
 "use strict";
-var __classPrivateFieldSet = (this && this.__classPrivateFieldSet) || function (receiver, state, value, kind, f) {
-    if (kind === "m") throw new TypeError("Private method is not writable");
-    if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a setter");
-    if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot write private member to an object whose class did not declare it");
-    return (kind === "a" ? f.call(receiver, value) : f ? f.value = value : state.set(receiver, value)), value;
-};
-var __classPrivateFieldGet = (this && this.__classPrivateFieldGet) || function (receiver, state, kind, f) {
-    if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a getter");
-    if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot read private member from an object whose class did not declare it");
-    return kind === "m" ? f : kind === "a" ? f.call(receiver) : f ? f.value : state.get(receiver);
-};
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
-var _TextFileSync_tempFilename, _TextFileSync_filename;
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.TextFileSync = void 0;
 const fs_1 = __importDefault(require("fs"));
 const path_1 = __importDefault(require("path"));
 class TextFileSync {
+    #tempFilename;
+    #filename;
     constructor(filename) {
-        _TextFileSync_tempFilename.set(this, void 0);
-        _TextFileSync_filename.set(this, void 0);
-        __classPrivateFieldSet(this, _TextFileSync_filename, filename, "f");
-        __classPrivateFieldSet(this, _TextFileSync_tempFilename, path_1.default.join(path_1.default.dirname(filename), `.${path_1.default.basename(filename)}.tmp`), "f");
+        this.#filename = filename;
+        this.#tempFilename = path_1.default.join(path_1.default.dirname(filename), `.${path_1.default.basename(filename)}.tmp`);
     }
     read() {
         let data;
         try {
-            data = fs_1.default.readFileSync(__classPrivateFieldGet(this, _TextFileSync_filename, "f"), 'utf-8');
+            data = fs_1.default.readFileSync(this.#filename, 'utf-8');
         }
         catch (e) {
             if (e.code === 'ENOENT') {
@@ -39,9 +27,8 @@ class TextFileSync {
         return data;
     }
     write(str) {
-        fs_1.default.writeFileSync(__classPrivateFieldGet(this, _TextFileSync_tempFilename, "f"), str);
-        fs_1.default.renameSync(__classPrivateFieldGet(this, _TextFileSync_tempFilename, "f"), __classPrivateFieldGet(this, _TextFileSync_filename, "f"));
+        fs_1.default.writeFileSync(this.#tempFilename, str);
+        fs_1.default.renameSync(this.#tempFilename, this.#filename);
     }
 }
 exports.TextFileSync = TextFileSync;
-_TextFileSync_tempFilename = new WeakMap(), _TextFileSync_filename = new WeakMap();

--- a/dist/cjs/api/loggers/TypeORMLogger.js
+++ b/dist/cjs/api/loggers/TypeORMLogger.js
@@ -4,6 +4,8 @@ const typeorm_1 = require("typeorm");
 const TypeORMWatcher_1 = require("../watchers/TypeORMWatcher");
 const Telescope_1 = require("../Telescope");
 class TypeORMLogger extends typeorm_1.AbstractLogger {
+    eventEmitter;
+    telescopeTable;
     constructor({ options = true, telescopeTable = 'telescopes' } = {
         options: true,
         telescopeTable: 'telescopes'

--- a/dist/cjs/api/watchers/ClientRequestWatcher.js
+++ b/dist/cjs/api/watchers/ClientRequestWatcher.js
@@ -38,6 +38,11 @@ class ClientRequestWatcherEntry extends WatcherEntry_js_1.default {
 }
 exports.ClientRequestWatcherEntry = ClientRequestWatcherEntry;
 class ClientRequestWatcher {
+    static entryType = WatcherEntry_js_1.WatcherEntryCollectionType.clientRequest;
+    static ignoreUrls = [];
+    batchId;
+    request;
+    response;
     constructor(request, response, batchId) {
         this.batchId = batchId;
         this.request = request;
@@ -98,5 +103,3 @@ class ClientRequestWatcher {
     }
 }
 exports.default = ClientRequestWatcher;
-ClientRequestWatcher.entryType = WatcherEntry_js_1.WatcherEntryCollectionType.clientRequest;
-ClientRequestWatcher.ignoreUrls = [];

--- a/dist/cjs/api/watchers/DumpWatcher.js
+++ b/dist/cjs/api/watchers/DumpWatcher.js
@@ -41,6 +41,8 @@ function dump(data) {
 }
 exports.dump = dump;
 class DumpWatcher {
+    static entryType = WatcherEntry_js_1.WatcherEntryCollectionType.dump;
+    data;
     constructor(data) {
         this.data = data;
     }
@@ -52,4 +54,3 @@ class DumpWatcher {
     }
 }
 exports.default = DumpWatcher;
-DumpWatcher.entryType = WatcherEntry_js_1.WatcherEntryCollectionType.dump;

--- a/dist/cjs/api/watchers/ErrorWatcher.js
+++ b/dist/cjs/api/watchers/ErrorWatcher.js
@@ -39,6 +39,10 @@ class ErrorWatcherEntry extends WatcherEntry_js_1.default {
 }
 exports.ErrorWatcherEntry = ErrorWatcherEntry;
 class ErrorWatcher {
+    static entryType = WatcherEntry_js_1.WatcherEntryCollectionType.exception;
+    static ignoreErrors = [];
+    error;
+    batchId;
     constructor(error, batchId) {
         this.error = error;
         this.batchId = batchId;
@@ -130,5 +134,3 @@ class ErrorWatcher {
     }
 }
 exports.default = ErrorWatcher;
-ErrorWatcher.entryType = WatcherEntry_js_1.WatcherEntryCollectionType.exception;
-ErrorWatcher.ignoreErrors = [];

--- a/dist/cjs/api/watchers/LogWatcher.js
+++ b/dist/cjs/api/watchers/LogWatcher.js
@@ -44,6 +44,9 @@ class LogWatcherEntry extends WatcherEntry_js_1.default {
 }
 exports.LogWatcherEntry = LogWatcherEntry;
 class LogWatcher {
+    static entryType = WatcherEntry_js_1.WatcherEntryCollectionType.log;
+    data;
+    batchId;
     constructor(data, level, batchId) {
         this.batchId = batchId;
         this.data = {
@@ -95,4 +98,3 @@ class LogWatcher {
     }
 }
 exports.default = LogWatcher;
-LogWatcher.entryType = WatcherEntry_js_1.WatcherEntryCollectionType.log;

--- a/dist/cjs/api/watchers/RequestWatcher.js
+++ b/dist/cjs/api/watchers/RequestWatcher.js
@@ -47,8 +47,18 @@ class RequestWatcherEntry extends WatcherEntry_js_1.default {
 }
 exports.RequestWatcherEntry = RequestWatcherEntry;
 class RequestWatcher {
+    static entryType = WatcherEntry_js_1.WatcherEntryCollectionType.request;
+    static paramsToHide = ['password', 'token', '_csrf'];
+    static ignorePaths = [];
+    static responseSizeLimit = 64;
+    batchId;
+    request;
+    response;
+    responseBody = '';
+    startTime;
+    getUser;
+    controllerAction;
     constructor(request, response, batchId, getUser) {
-        this.responseBody = '';
         this.batchId = batchId;
         this.request = request;
         this.response = response;
@@ -92,7 +102,7 @@ class RequestWatcher {
         return this.request.body;
     }
     filter(params, key) {
-        if (params.hasOwnProperty(key) && RequestWatcher.paramsToHide.includes(key)) {
+        if (Object.hasOwn(params, key) && RequestWatcher.paramsToHide.includes(key)) {
             return Object.assign(params, { [key]: '********' });
         }
         return params;
@@ -125,7 +135,3 @@ class RequestWatcher {
     }
 }
 exports.default = RequestWatcher;
-RequestWatcher.entryType = WatcherEntry_js_1.WatcherEntryCollectionType.request;
-RequestWatcher.paramsToHide = ['password', 'token', '_csrf'];
-RequestWatcher.ignorePaths = [];
-RequestWatcher.responseSizeLimit = 64;

--- a/dist/cjs/api/watchers/TypeORMWatcher.js
+++ b/dist/cjs/api/watchers/TypeORMWatcher.js
@@ -49,6 +49,9 @@ class TypeORMWatcherEntry extends WatcherEntry_js_1.default {
 }
 exports.TypeORMWatcherEntry = TypeORMWatcherEntry;
 class TypeORMWatcher {
+    static entryType = WatcherEntry_js_1.WatcherEntryCollectionType.log;
+    data;
+    batchId;
     constructor(data, level, batchId) {
         this.batchId = batchId;
         this.data = { level, data };
@@ -65,4 +68,3 @@ class TypeORMWatcher {
     }
 }
 exports.default = TypeORMWatcher;
-TypeORMWatcher.entryType = WatcherEntry_js_1.WatcherEntryCollectionType.log;

--- a/dist/esm/api/DB.js
+++ b/dist/esm/api/DB.js
@@ -1,6 +1,8 @@
 import LowDriver from "./drivers/LowDriver.js";
 import { WatcherEntryCollectionType } from "./WatcherEntry.js";
 class DB {
+    static driver = LowDriver;
+    static db;
     constructor() {
         DB.db = new DB.driver();
     }
@@ -40,5 +42,4 @@ class DB {
         return DB.db;
     }
 }
-DB.driver = LowDriver;
 export default DB;

--- a/dist/esm/api/Telescope.js
+++ b/dist/esm/api/Telescope.js
@@ -13,6 +13,16 @@ import EventEmitter from 'node:events';
 const telescopeEmitter = new EventEmitter();
 export const eventEmitter = telescopeEmitter;
 export default class Telescope {
+    static enabledWatchers = [
+        RequestWatcher,
+        ErrorWatcher,
+        ClientRequestWatcher,
+        DumpWatcher,
+        LogWatcher
+    ];
+    app;
+    batchId;
+    static enableClient = true;
     constructor(app) {
         this.app = app;
     }
@@ -122,11 +132,3 @@ export default class Telescope {
         this.app.get('/telescope/', (request, response) => response.redirect('/telescope/requests'));
     }
 }
-Telescope.enabledWatchers = [
-    RequestWatcher,
-    ErrorWatcher,
-    ClientRequestWatcher,
-    DumpWatcher,
-    LogWatcher
-];
-Telescope.enableClient = true;

--- a/dist/esm/api/Telescope.js
+++ b/dist/esm/api/Telescope.js
@@ -103,7 +103,7 @@ export default class Telescope {
         });
     }
     resolveDir() {
-        let dir = process.cwd() + '/node_modules/@damianchojnacki/telescope/dist/';
+        let dir = process.cwd() + '/node_modules/@asule/node-telescope/dist/';
         if (!existsSync(dir + 'index.html')) {
             dir = path.join(process.cwd(), '/dist/');
         }

--- a/dist/esm/api/WatcherEntry.js
+++ b/dist/esm/api/WatcherEntry.js
@@ -18,6 +18,14 @@ export var WatcherEntryCollectionType;
     WatcherEntryCollectionType["clientRequest"] = "client-requests";
 })(WatcherEntryCollectionType || (WatcherEntryCollectionType = {}));
 export default class WatcherEntry {
+    content;
+    created_at;
+    family_hash;
+    id;
+    batchId;
+    sequence;
+    tags;
+    type;
     constructor(name, data, batchId) {
         this.id = uuidv4();
         this.created_at = new Date().toISOString();

--- a/dist/esm/api/drivers/JSONFileSyncAdapter.js
+++ b/dist/esm/api/drivers/JSONFileSyncAdapter.js
@@ -1,23 +1,23 @@
-var __classPrivateFieldSet = (this && this.__classPrivateFieldSet) || function (receiver, state, value, kind, f) {
-    if (kind === "m") throw new TypeError("Private method is not writable");
-    if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a setter");
-    if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot write private member to an object whose class did not declare it");
-    return (kind === "a" ? f.call(receiver, value) : f ? f.value = value : state.set(receiver, value)), value;
-};
-var __classPrivateFieldGet = (this && this.__classPrivateFieldGet) || function (receiver, state, kind, f) {
-    if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a getter");
-    if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot read private member from an object whose class did not declare it");
-    return kind === "m" ? f : kind === "a" ? f.call(receiver) : f ? f.value : state.get(receiver);
-};
-var _JSONFileSyncAdapter_adapter;
 import { TextFileSync } from "./TextFileSync.js";
 export default class JSONFileSyncAdapter {
+    #adapter;
     constructor(filename) {
-        _JSONFileSyncAdapter_adapter.set(this, void 0);
-        __classPrivateFieldSet(this, _JSONFileSyncAdapter_adapter, new TextFileSync(filename), "f");
+        this.#adapter = new TextFileSync(filename);
     }
+    static getRefReplacer = () => {
+        const seen = new WeakSet();
+        return (key, value) => {
+            if (typeof value === "object" && value !== null) {
+                if (seen.has(value)) {
+                    return '[Circular]';
+                }
+                seen.add(value);
+            }
+            return value;
+        };
+    };
     read() {
-        const data = __classPrivateFieldGet(this, _JSONFileSyncAdapter_adapter, "f").read();
+        const data = this.#adapter.read();
         if (data === null) {
             return null;
         }
@@ -26,19 +26,6 @@ export default class JSONFileSyncAdapter {
         }
     }
     write(obj) {
-        __classPrivateFieldGet(this, _JSONFileSyncAdapter_adapter, "f").write(JSON.stringify(obj, JSONFileSyncAdapter.getRefReplacer(), 2));
+        this.#adapter.write(JSON.stringify(obj, JSONFileSyncAdapter.getRefReplacer(), 2));
     }
 }
-_JSONFileSyncAdapter_adapter = new WeakMap();
-JSONFileSyncAdapter.getRefReplacer = () => {
-    const seen = new WeakSet();
-    return (key, value) => {
-        if (typeof value === "object" && value !== null) {
-            if (seen.has(value)) {
-                return '[Circular]';
-            }
-            seen.add(value);
-        }
-        return value;
-    };
-};

--- a/dist/esm/api/drivers/LowDriver.js
+++ b/dist/esm/api/drivers/LowDriver.js
@@ -1,15 +1,16 @@
 import { unlinkSync } from "fs";
 import JSONFileSyncAdapter from "./JSONFileSyncAdapter.js";
 export default class LowDriver {
+    adapter;
+    db = {
+        requests: [],
+        exceptions: [],
+        dumps: [],
+        logs: [],
+        queries: [],
+        "client-requests": [],
+    };
     constructor() {
-        this.db = {
-            requests: [],
-            exceptions: [],
-            dumps: [],
-            logs: [],
-            queries: [],
-            "client-requests": [],
-        };
         this.adapter = new JSONFileSyncAdapter('db.json');
         this.adapter.read();
     }

--- a/dist/esm/api/drivers/MemoryDriver.js
+++ b/dist/esm/api/drivers/MemoryDriver.js
@@ -1,4 +1,5 @@
 export default class MemoryDriver {
+    db;
     constructor() {
         this.db = {
             requests: [],

--- a/dist/esm/api/drivers/TextFileSync.js
+++ b/dist/esm/api/drivers/TextFileSync.js
@@ -1,28 +1,16 @@
-var __classPrivateFieldSet = (this && this.__classPrivateFieldSet) || function (receiver, state, value, kind, f) {
-    if (kind === "m") throw new TypeError("Private method is not writable");
-    if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a setter");
-    if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot write private member to an object whose class did not declare it");
-    return (kind === "a" ? f.call(receiver, value) : f ? f.value = value : state.set(receiver, value)), value;
-};
-var __classPrivateFieldGet = (this && this.__classPrivateFieldGet) || function (receiver, state, kind, f) {
-    if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a getter");
-    if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot read private member from an object whose class did not declare it");
-    return kind === "m" ? f : kind === "a" ? f.call(receiver) : f ? f.value : state.get(receiver);
-};
-var _TextFileSync_tempFilename, _TextFileSync_filename;
 import fs from 'fs';
 import path from 'path';
 export class TextFileSync {
+    #tempFilename;
+    #filename;
     constructor(filename) {
-        _TextFileSync_tempFilename.set(this, void 0);
-        _TextFileSync_filename.set(this, void 0);
-        __classPrivateFieldSet(this, _TextFileSync_filename, filename, "f");
-        __classPrivateFieldSet(this, _TextFileSync_tempFilename, path.join(path.dirname(filename), `.${path.basename(filename)}.tmp`), "f");
+        this.#filename = filename;
+        this.#tempFilename = path.join(path.dirname(filename), `.${path.basename(filename)}.tmp`);
     }
     read() {
         let data;
         try {
-            data = fs.readFileSync(__classPrivateFieldGet(this, _TextFileSync_filename, "f"), 'utf-8');
+            data = fs.readFileSync(this.#filename, 'utf-8');
         }
         catch (e) {
             if (e.code === 'ENOENT') {
@@ -33,8 +21,7 @@ export class TextFileSync {
         return data;
     }
     write(str) {
-        fs.writeFileSync(__classPrivateFieldGet(this, _TextFileSync_tempFilename, "f"), str);
-        fs.renameSync(__classPrivateFieldGet(this, _TextFileSync_tempFilename, "f"), __classPrivateFieldGet(this, _TextFileSync_filename, "f"));
+        fs.writeFileSync(this.#tempFilename, str);
+        fs.renameSync(this.#tempFilename, this.#filename);
     }
 }
-_TextFileSync_tempFilename = new WeakMap(), _TextFileSync_filename = new WeakMap();

--- a/dist/esm/api/loggers/TypeORMLogger.js
+++ b/dist/esm/api/loggers/TypeORMLogger.js
@@ -2,6 +2,8 @@ import { AbstractLogger } from "typeorm";
 import { LogType } from "../watchers/TypeORMWatcher";
 import { eventEmitter } from "../Telescope";
 export default class TypeORMLogger extends AbstractLogger {
+    eventEmitter;
+    telescopeTable;
     constructor({ options = true, telescopeTable = 'telescopes' } = {
         options: true,
         telescopeTable: 'telescopes'

--- a/dist/esm/api/watchers/ClientRequestWatcher.js
+++ b/dist/esm/api/watchers/ClientRequestWatcher.js
@@ -8,6 +8,11 @@ export class ClientRequestWatcherEntry extends WatcherEntry {
     }
 }
 export default class ClientRequestWatcher {
+    static entryType = WatcherEntryCollectionType.clientRequest;
+    static ignoreUrls = [];
+    batchId;
+    request;
+    response;
     constructor(request, response, batchId) {
         this.batchId = batchId;
         this.request = request;
@@ -67,5 +72,3 @@ export default class ClientRequestWatcher {
         return checks.includes(true);
     }
 }
-ClientRequestWatcher.entryType = WatcherEntryCollectionType.clientRequest;
-ClientRequestWatcher.ignoreUrls = [];

--- a/dist/esm/api/watchers/DumpWatcher.js
+++ b/dist/esm/api/watchers/DumpWatcher.js
@@ -10,6 +10,8 @@ export function dump(data) {
     watcher.save();
 }
 export default class DumpWatcher {
+    static entryType = WatcherEntryCollectionType.dump;
+    data;
     constructor(data) {
         this.data = data;
     }
@@ -20,4 +22,3 @@ export default class DumpWatcher {
         DB.dumps().save(entry);
     }
 }
-DumpWatcher.entryType = WatcherEntryCollectionType.dump;

--- a/dist/esm/api/watchers/ErrorWatcher.js
+++ b/dist/esm/api/watchers/ErrorWatcher.js
@@ -9,6 +9,10 @@ export class ErrorWatcherEntry extends WatcherEntry {
     }
 }
 export default class ErrorWatcher {
+    static entryType = WatcherEntryCollectionType.exception;
+    static ignoreErrors = [];
+    error;
+    batchId;
     constructor(error, batchId) {
         this.error = error;
         this.batchId = batchId;
@@ -99,5 +103,3 @@ export default class ErrorWatcher {
         });
     }
 }
-ErrorWatcher.entryType = WatcherEntryCollectionType.exception;
-ErrorWatcher.ignoreErrors = [];

--- a/dist/esm/api/watchers/LogWatcher.js
+++ b/dist/esm/api/watchers/LogWatcher.js
@@ -14,6 +14,9 @@ export class LogWatcherEntry extends WatcherEntry {
     }
 }
 export default class LogWatcher {
+    static entryType = WatcherEntryCollectionType.log;
+    data;
+    batchId;
     constructor(data, level, batchId) {
         this.batchId = batchId;
         this.data = {
@@ -64,4 +67,3 @@ export default class LogWatcher {
         return message;
     }
 }
-LogWatcher.entryType = WatcherEntryCollectionType.log;

--- a/dist/esm/api/watchers/RequestWatcher.js
+++ b/dist/esm/api/watchers/RequestWatcher.js
@@ -17,8 +17,18 @@ export class RequestWatcherEntry extends WatcherEntry {
     }
 }
 export default class RequestWatcher {
+    static entryType = WatcherEntryCollectionType.request;
+    static paramsToHide = ['password', 'token', '_csrf'];
+    static ignorePaths = [];
+    static responseSizeLimit = 64;
+    batchId;
+    request;
+    response;
+    responseBody = '';
+    startTime;
+    getUser;
+    controllerAction;
     constructor(request, response, batchId, getUser) {
-        this.responseBody = '';
         this.batchId = batchId;
         this.request = request;
         this.response = response;
@@ -62,7 +72,7 @@ export default class RequestWatcher {
         return this.request.body;
     }
     filter(params, key) {
-        if (params.hasOwnProperty(key) && RequestWatcher.paramsToHide.includes(key)) {
+        if (Object.hasOwn(params, key) && RequestWatcher.paramsToHide.includes(key)) {
             return Object.assign(params, { [key]: '********' });
         }
         return params;
@@ -94,7 +104,3 @@ export default class RequestWatcher {
         return checks.includes(true);
     }
 }
-RequestWatcher.entryType = WatcherEntryCollectionType.request;
-RequestWatcher.paramsToHide = ['password', 'token', '_csrf'];
-RequestWatcher.ignorePaths = [];
-RequestWatcher.responseSizeLimit = 64;

--- a/dist/esm/api/watchers/TypeORMWatcher.js
+++ b/dist/esm/api/watchers/TypeORMWatcher.js
@@ -19,6 +19,9 @@ export class TypeORMWatcherEntry extends WatcherEntry {
     }
 }
 export default class TypeORMWatcher {
+    static entryType = WatcherEntryCollectionType.log;
+    data;
+    batchId;
     constructor(data, level, batchId) {
         this.batchId = batchId;
         this.data = { level, data };
@@ -34,4 +37,3 @@ export default class TypeORMWatcher {
         await DB.logs().save(entry);
     }
 }
-TypeORMWatcher.entryType = WatcherEntryCollectionType.log;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@damianchojnacki/telescope",
-  "version": "1.0.6",
+  "name": "@asule/node-telescope",
+  "version": "1.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@damianchojnacki/telescope",
-      "version": "1.0.6",
+      "name": "@asule/node-telescope",
+      "version": "1.0.9",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.9.0",

--- a/src/api/Telescope.ts
+++ b/src/api/Telescope.ts
@@ -183,7 +183,7 @@ export default class Telescope
 
     private resolveDir(): string
     {
-        let dir = process.cwd() + '/node_modules/@damianchojnacki/telescope/dist/'
+        let dir = process.cwd() + '/node_modules/@asule/node-telescope/dist/'
 
         if(!existsSync(dir + 'index.html')){
             dir = path.join(process.cwd(), '/dist/')

--- a/src/api/watchers/RequestWatcher.ts
+++ b/src/api/watchers/RequestWatcher.ts
@@ -134,7 +134,7 @@ export default class RequestWatcher
 
     private filter(params: object, key: string): object
     {
-        if (params.hasOwnProperty(key) && RequestWatcher.paramsToHide.includes(key)) {
+        if (Object.hasOwn(params, key) && RequestWatcher.paramsToHide.includes(key)) {
             return Object.assign(params, {[key]: '********'})
         }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "experimentalDecorators": true,
-        "target": "ES2021",
+        "target": "ES2022",
         "module": "ESNext",
         "outDir": "./dist",
         "rootDir": "./src",


### PR DESCRIPTION
# Summary

This pull request includes updates to improve compatibility and maintainability by modifying dependencies and modernizing code practices. The most important changes involve updating a dependency path in the `Telescope` class and replacing a deprecated method in the `RequestWatcher` class.

### Dependency Update:
* [`src/api/Telescope.ts`](diffhunk://#diff-cf49f484473f24ded4fae78007bd346f75921997a89e5491715a9e7f292b63acL186-R186): Updated the dependency path in the `resolveDir` method to use `@asule/node-telescope` instead of `@damianchojnacki/telescope`. This ensures the application uses the correct library.

### Code Modernization:
* [`src/api/watchers/RequestWatcher.ts`](diffhunk://#diff-1999c7eb608e6a085a366b92ab173fe91bb557f66172021de1747c318a509f66L137-R137): Replaced the deprecated `hasOwnProperty` method with the modern `Object.hasOwn` in the `filter` method to improve code reliability and align with best practices.

# Problem It Solves

In a request with `Content-Type` set as `multipart/form-data`, we get a exception with the following message: `TypeError: params.hasOwnProperty is not a function`.

The call stack points to the `filter` method of the `RequestWatcher`. It seems like the object params does not have the `hasOwnProperty` as it's method in case of form data.

# The Solution

Usage of `Object.hasOwn()` as it is intended as a replacement for `Object.prototype.hasOwnProperty()`.